### PR TITLE
Single database instance fix.

### DIFF
--- a/application/api/capacityservice/serializers/model_serializers.py
+++ b/application/api/capacityservice/serializers/model_serializers.py
@@ -55,7 +55,7 @@ class CapacityStatusModelSerializer(serializers.ModelSerializer):
         ragStatusColor = validated_data.get("capacitystatus", instance.capacitystatus)[
             "color"
         ]
-        capStatus = Capacitystatuses.objects.db_manager("dos").get(color=ragStatusColor)
+        capStatus = Capacitystatuses.objects.get(color=ragStatusColor)
 
         # Adapted from the super class's update method
         for attr, value in validated_data.items():

--- a/application/api/capacityservice/views.py
+++ b/application/api/capacityservice/views.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class CapacityStatusView(RetrieveUpdateAPIView):
-    queryset = ServiceCapacities.objects.db_manager("dos").all()
+    queryset = ServiceCapacities.objects.all()
     serializer_class = CapacityStatusModelSerializer
     lookup_field = "service__uid"
 
@@ -78,7 +78,7 @@ class CapacityStatusView(RetrieveUpdateAPIView):
     """
     def _process_service_status_retrieval(self, request, service__uid):
 
-        service_status = ServiceCapacities.objects.db_manager("dos").get(
+        service_status = ServiceCapacities.objects.get(
             service__uid=service__uid
         )
 

--- a/application/api/settings.py
+++ b/application/api/settings.py
@@ -43,10 +43,6 @@ SECURE_HSTS_SECONDS = 30  # Set low for development (original 3600)
 
 INSTALLED_APPS = [
     "rest_framework",
-    # We seem to need this one as a dependency for the rest_framework APP
-    "django.contrib.auth",
-    # We seem to need this one as a dependency for models.
-    "django.contrib.contenttypes",
     "django.contrib.staticfiles",
     "api.capacityservice",
     "drf_yasg",
@@ -62,7 +58,6 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
@@ -92,10 +87,6 @@ WSGI_APPLICATION = "api.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
-    },
-    "dos": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
         "OPTIONS": {"options": "-c search_path=pathwaysdos"},
         "HOST": os.getenv("DB_HOST", "db-dos"),
@@ -152,19 +143,6 @@ LOGGING = {
 }
 
 
-# Password validation
-# https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
-
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
-]
-
-
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/
 
@@ -189,3 +167,10 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 # This is so we can trace a request all the way through.
 # https://django-request-id.readthedocs.io/en/latest/
 REQUEST_ID_HEADER = None
+
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [],
+    'DEFAULT_PERMISSION_CLASSES': [],
+    'UNAUTHENTICATED_USER': None,
+}

--- a/application/api/urls.py
+++ b/application/api/urls.py
@@ -37,7 +37,6 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path("api/v0.0.1/capacity/", include("api.capacityservice.urls")),
-    path("apidoc/", include("rest_framework.urls", namespace="rest_framework")),
     url(
         r"^apidoc(?P<format>\.json|\.yaml)$",
         schema_view.without_ui(cache_timeout=0),


### PR DESCRIPTION
These changes allow the application to run without the need of a second database (as required by `django.contrib.contenttypes` which, along with `django.contrib.auth` is removed in this PR).

During the testing of this branch I was able to GET data from the database, thus proving the revised configuration worked. However, I encountered the following Python-related problem:

```
File "/project/application/api/capacityservice/serializers/payload_serializer.py", line 86, in convertToModel
    data["resetdatetime"] = self._resetTime(
  File "/tmp/.packages/django/http/request.py", line 467, in __setitem__
    self._assert_mutable()
  File "/tmp/.packages/django/http/request.py", line 464, in _assert_mutable
    raise AttributeError("This QueryDict instance is immutable")
AttributeError: This QueryDict instance is immutable
```

This is on Python `3.7.6` and Django `3.0.2.final`. By the looks of it you're trying to assign a new value to the `data` object (an instance of QueryDIct) which is immutable. This request was created via the browser based form. Perhaps this is the reason? (Also, I noticed that the browser based form shown by the application is incomplete and requires some additional validation step to do with the time-out for the new RAG status being set).