### PR TITLE
Initial user management database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ project-build: project-config project-stop
 	make docker-image NAME=api
 	make docker-image NAME=postgres
 
+project-migrate:
+	make docker-run-python IMAGE=$(DOCKER_REGISTRY)/api:latest \
+	DIR=application \
+	CMD="python manage.py migrate"
+
 project-restart:
 	make \
 		project-stop \

--- a/application/api/settings.py
+++ b/application/api/settings.py
@@ -94,8 +94,12 @@ WSGI_APPLICATION = "api.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "HOST": os.getenv("DB_HOST", "db-dos"),
+        "PORT": os.getenv("DB_PORT", "5432"),
+        "NAME": os.getenv("DB_NAME", "user_mngt"),
+        "USER": os.getenv("DB_USERNAME", "postgres"),
+        "PASSWORD": os.getenv("DB_PASSWORD", "postgres"),
     },
     "dos": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",

--- a/data/sql/06-create_initial_user_mngt_db.sql
+++ b/data/sql/06-create_initial_user_mngt_db.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE user_mngt;
+
+


### PR DESCRIPTION
This pull request is to create and configure the initial setup for a separate database to hold and manage the users of the API.

I have created another make target called project-migrate.  Please use this target to migrate any database changes required.