### PR TITLE
Add check against DoS for edit service rights

### DIFF
--- a/application/api/dos/queries.py
+++ b/application/api/dos/queries.py
@@ -1,0 +1,31 @@
+from django.db import connections
+
+sql_temp_01 = "SELECT EXISTS(SELECT s from services s where s.uid = %s)"
+sql_temp_02 = "SELECT EXISTS(SELECT u from users u \
+    join userpermissions up on up.userid = u.id \
+    join userservices us on us.userid = u.id \
+    join services s on s.id = us.serviceid \
+    where u.id = %s and up.permissionid = 3 and s.uid = %s)"
+can_user_edit_service_sql = """SELECT EXISTS(SELECT u FROM users u
+    JOIN userpermissions up ON up.userid = u.id
+    JOIN userservices us ON us.userid = u.id
+    JOIN services s ON s.id = us.serviceid
+    WHERE u.id = %s AND up.permissionid = 3 AND  us.serviceid in (
+        WITH RECURSIVE user_accessible_services AS (
+            select s.id, s.uid, s.parentid from services s
+            where s.uid = %s
+            union
+            select s.id, s.uid, s.parentid from services s
+            join user_accessible_services d on d.parentid = s.id
+        )
+        select id from user_accessible_services)
+    );"""
+
+
+def can_user_edit_service(userid, service_uid):
+    with connections["dos"].cursor() as cursor:
+
+        cursor.execute(can_user_edit_service_sql, [userid, service_uid])
+        row = cursor.fetchone()
+
+    return row[0]

--- a/application/api/dos/queries.py
+++ b/application/api/dos/queries.py
@@ -1,19 +1,19 @@
 from django.db import connections
 
 
-can_user_edit_service_sql = """SELECT EXISTS(SELECT u FROM users u
+can_user_edit_service_sql = """SELECT EXISTS(SELECT 1 FROM users u
     JOIN userpermissions up ON up.userid = u.id
     JOIN userservices us ON us.userid = u.id
     JOIN services s ON s.id = us.serviceid
     WHERE u.id = %s AND up.permissionid = 3 AND  us.serviceid in (
-        WITH RECURSIVE user_accessible_services AS (
-            select s.id, s.uid, s.parentid from services s
+        WITH RECURSIVE service_ancestry AS (
+            select s.id, s.parentid from services s
             where s.uid = %s
             union
-            select s.id, s.uid, s.parentid from services s
-            join user_accessible_services d on d.parentid = s.id
+            select s.id, s.parentid from services s
+            join service_ancestry d on d.parentid = s.id
         )
-        select id from user_accessible_services)
+        select id from service_ancestry)
     );"""
 
 

--- a/application/api/dos/queries.py
+++ b/application/api/dos/queries.py
@@ -1,11 +1,6 @@
 from django.db import connections
 
-sql_temp_01 = "SELECT EXISTS(SELECT s from services s where s.uid = %s)"
-sql_temp_02 = "SELECT EXISTS(SELECT u from users u \
-    join userpermissions up on up.userid = u.id \
-    join userservices us on us.userid = u.id \
-    join services s on s.id = us.serviceid \
-    where u.id = %s and up.permissionid = 3 and s.uid = %s)"
+
 can_user_edit_service_sql = """SELECT EXISTS(SELECT u FROM users u
     JOIN userpermissions up ON up.userid = u.id
     JOIN userservices us ON us.userid = u.id

--- a/application/api/dos/queries.py
+++ b/application/api/dos/queries.py
@@ -17,10 +17,10 @@ can_user_edit_service_sql = """SELECT EXISTS(SELECT 1 FROM users u
     );"""
 
 
-def can_user_edit_service(userid, service_uid):
+def can_user_edit_service(dos_user_id, service_uid):
     with connections["dos"].cursor() as cursor:
 
-        cursor.execute(can_user_edit_service_sql, [userid, service_uid])
+        cursor.execute(can_user_edit_service_sql, [dos_user_id, service_uid])
         row = cursor.fetchone()
 
     return row[0]

--- a/application/api/dos/tests/__init__.py
+++ b/application/api/dos/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_queries import *

--- a/application/api/dos/tests/test_queries.py
+++ b/application/api/dos/tests/test_queries.py
@@ -30,10 +30,26 @@ class TestQueries(unittest.TestCase):
         self.assertTrue(user_can_edit)
         print(user_can_edit)
 
+    def test_can_user_edit_service__is_not_linked_to_users(self):
+        "Test sql can_user_edit_service method, returns false when the service does not exist"
+        serviceUid = "fake-uid"
+        userId = 1000000001
+        user_can_edit = can_user_edit_service(userId, serviceUid)
+        self.assertFalse(user_can_edit)
+        print(user_can_edit)
+
     def test_can_user_edit_service__does_not_exists(self):
         "Test sql can_user_edit_service method, returns false when the service isn't linked to the user directly or by ancestry"
         serviceUid = "133102"
         userId = 1000000001
+        user_can_edit = can_user_edit_service(userId, serviceUid)
+        self.assertFalse(user_can_edit)
+        print(user_can_edit)
+
+    def test_can_user_edit_service__does_not_have_the_right_permissions(self):
+        "Test sql can_user_edit_service method, return false as the user does not have the correct permissions"
+        serviceUid = "153455"
+        userId = 1000000000
         user_can_edit = can_user_edit_service(userId, serviceUid)
         self.assertFalse(user_can_edit)
         print(user_can_edit)

--- a/application/api/dos/tests/test_queries.py
+++ b/application/api/dos/tests/test_queries.py
@@ -1,0 +1,39 @@
+import unittest
+
+from ..queries import can_user_edit_service
+
+
+class TestQueries(unittest.TestCase):
+    "Tests for dos query functions"
+
+    def test_can_user_edit_service__service_exists(self):
+        "Test sql can_user_edit_service method, return true when the service is linked directly to the user"
+        serviceUid = "153455"
+        userId = 1000000001
+        user_can_edit = can_user_edit_service(userId, serviceUid)
+        self.assertTrue(user_can_edit)
+        print(user_can_edit)
+
+    def test_can_user_edit_service__child_decendant_service_exists(self):
+        "Test sql can_user_edit_service method,returns true when the service's parent is linked to the user"
+        serviceUid = "149198"
+        userId = 1000000001
+        user_can_edit = can_user_edit_service(userId, serviceUid)
+        self.assertTrue(user_can_edit)
+        print(user_can_edit)
+
+    def test_can_user_edit_service__grandchild_decendant_service_exists(self):
+        "Test sql can_user_edit_service method, returns true when the service's grand parent is linked to the user"
+        serviceUid = "162172"
+        userId = 1000000001
+        user_can_edit = can_user_edit_service(userId, serviceUid)
+        self.assertTrue(user_can_edit)
+        print(user_can_edit)
+
+    def test_can_user_edit_service__does_not_exists(self):
+        "Test sql can_user_edit_service method, returns false when the service isn't linked to the user directly or by ancestry"
+        serviceUid = "133102"
+        userId = 1000000001
+        user_can_edit = can_user_edit_service(userId, serviceUid)
+        self.assertFalse(user_can_edit)
+        print(user_can_edit)

--- a/application/api/dos/tests/test_queries.py
+++ b/application/api/dos/tests/test_queries.py
@@ -8,42 +8,42 @@ class TestQueries(TestCase):
 
     def test_can_user_edit_service__service_exists(self):
         "Test sql can_user_edit_service method, return true when the service is linked directly to the user"
-        serviceUid = "153455"
-        userId = 1000000001
-        user_can_edit = can_user_edit_service(userId, serviceUid)
+        service_uid = "153455"
+        dos_user_id = 1000000001
+        user_can_edit = can_user_edit_service(dos_user_id, service_uid)
         self.assertTrue(user_can_edit)
 
     def test_can_user_edit_service__child_decendant_service_exists(self):
         "Test sql can_user_edit_service method,returns true when the service's parent is linked to the user"
-        serviceUid = "149198"
-        userId = 1000000001
-        user_can_edit = can_user_edit_service(userId, serviceUid)
+        service_uid = "149198"
+        dos_user_id = 1000000001
+        user_can_edit = can_user_edit_service(dos_user_id, service_uid)
         self.assertTrue(user_can_edit)
 
     def test_can_user_edit_service__grandchild_decendant_service_exists(self):
         "Test sql can_user_edit_service method, returns true when the service's grand parent is linked to the user"
-        serviceUid = "162172"
-        userId = 1000000001
-        user_can_edit = can_user_edit_service(userId, serviceUid)
+        service_uid = "162172"
+        dos_user_id = 1000000001
+        user_can_edit = can_user_edit_service(dos_user_id, service_uid)
         self.assertTrue(user_can_edit)
 
     def test_can_user_edit_service__is_not_linked_to_users(self):
         "Test sql can_user_edit_service method, returns false when the service does not exist"
-        serviceUid = "fake-uid"
-        userId = 1000000001
-        user_can_edit = can_user_edit_service(userId, serviceUid)
+        service_uid = "fake-uid"
+        dos_user_id = 1000000001
+        user_can_edit = can_user_edit_service(dos_user_id, service_uid)
         self.assertFalse(user_can_edit)
 
     def test_can_user_edit_service__does_not_exists(self):
         "Test sql can_user_edit_service method, returns false when the service isn't linked to the user directly or by ancestry"
-        serviceUid = "133102"
-        userId = 1000000001
-        user_can_edit = can_user_edit_service(userId, serviceUid)
+        service_uid = "133102"
+        dos_user_id = 1000000001
+        user_can_edit = can_user_edit_service(dos_user_id, service_uid)
         self.assertFalse(user_can_edit)
 
     def test_can_user_edit_service__does_not_have_the_right_permissions(self):
         "Test sql can_user_edit_service method, return false as the user does not have the correct permissions"
-        serviceUid = "153455"
-        userId = 1000000000
-        user_can_edit = can_user_edit_service(userId, serviceUid)
+        service_uid = "153455"
+        dos_user_id = 1000000000
+        user_can_edit = can_user_edit_service(dos_user_id, service_uid)
         self.assertFalse(user_can_edit)

--- a/application/api/dos/tests/test_queries.py
+++ b/application/api/dos/tests/test_queries.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from ..queries import can_user_edit_service
 
 
-class TestQueries(TestCase):
+class TestCanUserEditService(TestCase):
     "Tests for dos query functions"
 
     def test_can_user_edit_service__service_exists(self):

--- a/application/api/dos/tests/test_queries.py
+++ b/application/api/dos/tests/test_queries.py
@@ -1,9 +1,9 @@
-import unittest
+from unittest import TestCase
 
 from ..queries import can_user_edit_service
 
 
-class TestQueries(unittest.TestCase):
+class TestQueries(TestCase):
     "Tests for dos query functions"
 
     def test_can_user_edit_service__service_exists(self):
@@ -12,7 +12,6 @@ class TestQueries(unittest.TestCase):
         userId = 1000000001
         user_can_edit = can_user_edit_service(userId, serviceUid)
         self.assertTrue(user_can_edit)
-        print(user_can_edit)
 
     def test_can_user_edit_service__child_decendant_service_exists(self):
         "Test sql can_user_edit_service method,returns true when the service's parent is linked to the user"
@@ -20,7 +19,6 @@ class TestQueries(unittest.TestCase):
         userId = 1000000001
         user_can_edit = can_user_edit_service(userId, serviceUid)
         self.assertTrue(user_can_edit)
-        print(user_can_edit)
 
     def test_can_user_edit_service__grandchild_decendant_service_exists(self):
         "Test sql can_user_edit_service method, returns true when the service's grand parent is linked to the user"
@@ -28,7 +26,6 @@ class TestQueries(unittest.TestCase):
         userId = 1000000001
         user_can_edit = can_user_edit_service(userId, serviceUid)
         self.assertTrue(user_can_edit)
-        print(user_can_edit)
 
     def test_can_user_edit_service__is_not_linked_to_users(self):
         "Test sql can_user_edit_service method, returns false when the service does not exist"
@@ -36,7 +33,6 @@ class TestQueries(unittest.TestCase):
         userId = 1000000001
         user_can_edit = can_user_edit_service(userId, serviceUid)
         self.assertFalse(user_can_edit)
-        print(user_can_edit)
 
     def test_can_user_edit_service__does_not_exists(self):
         "Test sql can_user_edit_service method, returns false when the service isn't linked to the user directly or by ancestry"
@@ -44,7 +40,6 @@ class TestQueries(unittest.TestCase):
         userId = 1000000001
         user_can_edit = can_user_edit_service(userId, serviceUid)
         self.assertFalse(user_can_edit)
-        print(user_can_edit)
 
     def test_can_user_edit_service__does_not_have_the_right_permissions(self):
         "Test sql can_user_edit_service method, return false as the user does not have the correct permissions"
@@ -52,4 +47,3 @@ class TestQueries(unittest.TestCase):
         userId = 1000000000
         user_can_edit = can_user_edit_service(userId, serviceUid)
         self.assertFalse(user_can_edit)
-        print(user_can_edit)

--- a/application/api/settings.py
+++ b/application/api/settings.py
@@ -132,7 +132,7 @@ LOGGING = {
         "file": {
             "level": "DEBUG",
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": "./logs/capacity-status-api-debug.log",
+            "filename": os.path.join(BASE_DIR, "logs/capacity-status-api-debug.log"),
             "maxBytes": 1024 * 1024 * 15,  # 15MB
             "backupCount": 10,
             "formatter": "datetime_format",

--- a/data/sql/04-4-data-short-permissions-table.sql
+++ b/data/sql/04-4-data-short-permissions-table.sql
@@ -1,0 +1,1 @@
+INSERT INTO pathwaysdos.permissions (id, "name", "type", functionalarea) VALUES(3, 'editCapacity', 'EDIT', 'cmsOrg');

--- a/data/sql/04-5-data-test-user-tables.sql
+++ b/data/sql/04-5-data-test-user-tables.sql
@@ -1,0 +1,17 @@
+-- Add test user --
+insert into pathwaysdos.users (id, username, firstname, lastname, email, createdtime,status)
+select 1000000001, 'EditUser', 'EditUser', 'EditUser', null, now(),'ACTIVE'
+where not exists (select 'x' from pathwaysdos.users where id = 1000000001 or username = 'EditUser');
+
+ -- Grant required permissions to the new test user.
+insert into pathwaysdos.userpermissions (userid, permissionid)
+select 1000000001, per.id from pathwaysdos.permissions per where per.name = 'editCapacity';
+
+
+-- Link user to services
+insert into pathwaysdos.userservices (userid, serviceid)
+values(1000000001, '6811') -- uid = 153455
+
+-- Make some services Ancestors of the Linked services
+UPDATE pathwaysdos.services SET parentid=6811  WHERE id=2668;  -- uid = 149198
+UPDATE pathwaysdos.services SET parentid=2668  WHERE id=25774; -- uid = 162172

--- a/data/sql/04-5-data-test-user-tables.sql
+++ b/data/sql/04-5-data-test-user-tables.sql
@@ -13,9 +13,9 @@ select 1000000001, per.id from pathwaysdos.permissions per where per.name = 'edi
 
 -- Link user to services
 insert into pathwaysdos.userservices (userid, serviceid)
-values(1000000000, '6811') -- uid = 153455
+values(1000000000, 6811); -- uid = 153455
 insert into pathwaysdos.userservices (userid, serviceid)
-values(1000000001, '6811') -- uid = 153455
+values(1000000001, 6811); -- uid = 153455
 
 -- Make some services Ancestors of the Linked services
 UPDATE pathwaysdos.services SET parentid=6811  WHERE id=2668;  -- uid = 149198

--- a/data/sql/04-5-data-test-user-tables.sql
+++ b/data/sql/04-5-data-test-user-tables.sql
@@ -1,14 +1,19 @@
--- Add test user --
+-- Add test users --
+insert into pathwaysdos.users (id, username, firstname, lastname, email, createdtime,status)
+select 1000000000, 'ViewUser', 'ViewUser', 'ViewUser', null, now(),'ACTIVE'
+where not exists (select 'x' from pathwaysdos.users where id = 1000000000 or username = 'ViewUser');
+
 insert into pathwaysdos.users (id, username, firstname, lastname, email, createdtime,status)
 select 1000000001, 'EditUser', 'EditUser', 'EditUser', null, now(),'ACTIVE'
 where not exists (select 'x' from pathwaysdos.users where id = 1000000001 or username = 'EditUser');
 
- -- Grant required permissions to the new test user.
+ -- Grant required permissions to the new test users --
 insert into pathwaysdos.userpermissions (userid, permissionid)
 select 1000000001, per.id from pathwaysdos.permissions per where per.name = 'editCapacity';
 
-
 -- Link user to services
+insert into pathwaysdos.userservices (userid, serviceid)
+values(1000000000, '6811') -- uid = 153455
 insert into pathwaysdos.userservices (userid, serviceid)
 values(1000000001, '6811') -- uid = 153455
 


### PR DESCRIPTION
This adds a function for checking if a user has authorisation to edit a given service within DoS. 

Under the hood it uses a sql query to check if a given dos user (by id) has the permission to edit a service, and checks that a given service (by uid) is either directly linked to a user, or is the descendant of one that is.