### PR TITLE
Add Authorisation checks for api user to edit service via DoS user 

### DIFF
--- a/application/api/capacityauth/authorise.py
+++ b/application/api/capacityauth/authorise.py
@@ -1,0 +1,16 @@
+from api.dos.queries import can_user_edit_service
+from .models import User, ApiDosUserAssociations, Services
+
+
+def convert_api_user_to_dos_user_id(api_user):
+    aduas = ApiDosUserAssociations.objects.filter(apiuserid=api_user.id)
+    if len(aduas) > 0:
+        return aduas[0].dosuserid
+    return None
+
+
+def can_api_user_edit_service(api_user, service):
+    # one convert api user to a dos user id
+    dos_user_id = convert_api_user_to_dos_user_id(api_user)
+    # two check against dos and return true/false
+    return can_user_edit_service(dos_user_id, service.uid)

--- a/application/api/capacityauth/tests/__init__.py
+++ b/application/api/capacityauth/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_authorise import *

--- a/application/api/capacityauth/tests/test_authorise.py
+++ b/application/api/capacityauth/tests/test_authorise.py
@@ -70,13 +70,6 @@ class TestCanApiUserEdit_service(TestCase):
         mock_convert_api_user_to_dos_user_id.assert_called_with(api_user)
         mock_can_user_edit_service.assert_called_with(dos_user_id, service.uid)
 
-    # def test_can_api_user_edit_service__fail_usr_isn_t_linked_to_service(self):
-    #     "Test can api user edit service, fail user is not linked to service"
-    #     api_user = User(id=1)
-    #     service = Services.objects.db_manager("dos").filter(uid="133014")[0]
-    #     result = can_api_user_edit_service(api_user, service)
-    #     self.assertFalse(result)
-
     @mock.patch.object(authorise, "convert_api_user_to_dos_user_id")
     @mock.patch.object(authorise, "can_user_edit_service")
     def test_can_api_user_edit_service__fail_dos_lookup(

--- a/application/api/capacityauth/tests/test_authorise.py
+++ b/application/api/capacityauth/tests/test_authorise.py
@@ -1,0 +1,109 @@
+from unittest import TestCase, mock
+from django.db.models.query import QuerySet
+
+from ..authorise import User, Services, ApiDosUserAssociations
+from ..authorise import convert_api_user_to_dos_user_id
+from ..authorise import can_api_user_edit_service
+from .. import authorise
+
+
+class TestConvertApiUserToDosUserId(TestCase):
+    "Test authorising api user against dos"
+
+    @mock.patch.object(ApiDosUserAssociations.objects, "filter")
+    def test_convert_api_user_to_dos_user_id__success(self, mock_filter):
+        "Test convert api user to dos user id method, success"
+        api_user = User(id=1)
+        dos_user_id = 1000000001
+        mock_filter.return_value = (ApiDosUserAssociations(dosuserid=dos_user_id),)
+
+        returned_dos_user_id = convert_api_user_to_dos_user_id(api_user)
+
+        self.assertEqual(returned_dos_user_id, dos_user_id)
+        mock_filter.assert_called_with(apiuserid=api_user.id)
+
+    @mock.patch.object(ApiDosUserAssociations.objects, "filter")
+    def test_convert_api_user_to_dos_user_id__fail_api_user_does_not_exist(
+        self, mock_filter
+    ):
+        "Test convert api user to dos user id method, fail api user does not exist"
+        api_user = User(id=99)
+        expected_dos_user_id = None
+        mock_filter.return_value = ()
+
+        dos_user_id = convert_api_user_to_dos_user_id(api_user)
+
+        self.assertEqual(dos_user_id, expected_dos_user_id)
+        mock_filter.assert_called_with(apiuserid=api_user.id)
+
+    def test_convert_api_user_to_dos_user_id__fail_api_user_is_none(self):
+        """Test convert api user to dos user id method,
+        fail give api user is of none value"""
+        api_user = None
+        try:
+            dos_user_id = convert_api_user_to_dos_user_id(api_user)
+            self.fail(
+                "An AttributeError should have been throw for given 'None' api user"
+            )
+        except AttributeError:
+            "Success"
+
+
+class TestCanApiUserEdit_service(TestCase):
+    "Test can api user edit a dos service"
+
+    @mock.patch.object(authorise, "convert_api_user_to_dos_user_id")
+    @mock.patch.object(authorise, "can_user_edit_service")
+    def test_can_api_user_edit_service__success(
+        self, mock_can_user_edit_service, mock_convert_api_user_to_dos_user_id
+    ):
+        "Test can api user edit service, success"
+        api_user = User(id=22)
+        dos_user_id = 88
+        service = Services(uid="STUB00")
+        mock_convert_api_user_to_dos_user_id.return_value = dos_user_id
+        mock_can_user_edit_service.return_value = True
+
+        result = can_api_user_edit_service(api_user, service)
+
+        self.assertTrue(result)
+        mock_convert_api_user_to_dos_user_id.assert_called_with(api_user)
+        mock_can_user_edit_service.assert_called_with(dos_user_id, service.uid)
+
+    # def test_can_api_user_edit_service__fail_usr_isn_t_linked_to_service(self):
+    #     "Test can api user edit service, fail user is not linked to service"
+    #     api_user = User(id=1)
+    #     service = Services.objects.db_manager("dos").filter(uid="133014")[0]
+    #     result = can_api_user_edit_service(api_user, service)
+    #     self.assertFalse(result)
+
+    @mock.patch.object(authorise, "convert_api_user_to_dos_user_id")
+    @mock.patch.object(authorise, "can_user_edit_service")
+    def test_can_api_user_edit_service__fail_dos_lookup(
+        self, mock_can_user_edit_service, mock_convert_api_user_to_dos_user_id
+    ):
+        "Test can api user edit service, fail dos lookup"
+        api_user = User(id=22)
+        dos_user_id = 88
+        service = Services(uid="STUB00")
+        mock_convert_api_user_to_dos_user_id.return_value = dos_user_id
+        mock_can_user_edit_service.return_value = False
+
+        result = can_api_user_edit_service(api_user, service)
+
+        self.assertFalse(result)
+        mock_convert_api_user_to_dos_user_id.assert_called_with(api_user)
+        mock_can_user_edit_service.assert_called_with(dos_user_id, service.uid)
+
+    def test_can_api_user_edit_service__fail_service_is_none(self):
+        "Test can api user edit service, fail given service is of none value"
+        api_user = User(id=1)
+        service = None
+        try:
+            result = can_api_user_edit_service(api_user, service)
+            self.fail(
+                "An AttributeError should have been throw for given 'None' service"
+            )
+        except:
+            "Success"
+


### PR DESCRIPTION
Adds converting an API user to a DoS user id, and using it to see if the API user via the DoS user id, has authority to edit a given DoS Service (by uid).