### PR TITLE
Always set the reset status time to zero for a green status update

### DIFF
--- a/application/api/capacityservice/serializers/payload_serializer.py
+++ b/application/api/capacityservice/serializers/payload_serializer.py
@@ -67,11 +67,6 @@ class CapacityStatusRequestPayloadSerializer(serializers.Serializer):
 
     def to_internal_value(self, data):
         data["capacityStatus"] = data["capacityStatus"].upper()
-
-        # Set resetStatusIn to zero if we are transitioning into a GREEN capacity state.
-        if data["capacityStatus"] == "GREEN":
-            data["resetStatusIn"] = 0
-
         return super().to_internal_value(data)
 
     """
@@ -90,9 +85,7 @@ class CapacityStatusRequestPayloadSerializer(serializers.Serializer):
 
         payload_data = super().validated_data
 
-        data["resetdatetime"] = self._resetTime(
-            datetime.now(), payload_data["resetStatusIn"]
-        )
+        data["resetdatetime"] = self._resetTime(datetime.now(), payload_data)
 
         # Set capacity status
         data["capacitystatus"] = {"color": payload_data["capacityStatus"]}
@@ -117,7 +110,9 @@ class CapacityStatusRequestPayloadSerializer(serializers.Serializer):
 
         return data
 
-    def _resetTime(self, current_date, reset_time_in):
-        reset_time = current_date + timedelta(minutes=reset_time_in)
-        new_reset_dt = reset_time.astimezone().strftime("%Y-%m-%dT%H:%M:%SZ")
+    def _resetTime(self, current_date, payload_data):
+        new_reset_dt = None
+        if payload_data["capacityStatus"] != "GREEN":
+            reset_time = current_date + timedelta(minutes=payload_data["resetStatusIn"])
+            new_reset_dt = reset_time.astimezone().strftime("%Y-%m-%dT%H:%M:%SZ")
         return new_reset_dt

--- a/application/api/capacityservice/serializers/payload_serializer.py
+++ b/application/api/capacityservice/serializers/payload_serializer.py
@@ -67,6 +67,11 @@ class CapacityStatusRequestPayloadSerializer(serializers.Serializer):
 
     def to_internal_value(self, data):
         data["capacityStatus"] = data["capacityStatus"].upper()
+
+        # Set resetStatusIn to zero if we are transitioning into a GREEN capacity state.
+        if data["capacityStatus"] == "GREEN":
+            data["resetStatusIn"] = 0
+
         return super().to_internal_value(data)
 
     """

--- a/application/api/capacityservice/tests/test_serializers/test_payload_serializer.py
+++ b/application/api/capacityservice/tests/test_serializers/test_payload_serializer.py
@@ -12,12 +12,13 @@ class TestPayloadSerializer(unittest.TestCase):
     reset_status_in = 10
     notes = "Additional notes"
     api_username = "capApi"
+    api_user_id = 1234
 
-    def test_reset_time_1(self):
+    def test_reset_time_red(self):
         "Test reset_time method for RED status update"
 
         payload_data = {
-            "capacityStatus": self.capacity_status,
+            "capacityStatus": "RED",
             "resetStatusIn": 300,
         }
         current_time = datetime.now()
@@ -38,7 +39,7 @@ class TestPayloadSerializer(unittest.TestCase):
             "Returned reset data time is not as expected.",
         )
 
-    def test_reset_time_2(self):
+    def test_reset_time_amber(self):
         "Test reset_time method for AMBER status update"
 
         payload_data = {
@@ -63,7 +64,7 @@ class TestPayloadSerializer(unittest.TestCase):
             "Returned reset data time is not as expected.",
         )
 
-    def test_reset_time_3(self):
+    def test_reset_time_green(self):
         "Test reset_time method for GREEN status update"
 
         payload_data = {
@@ -80,18 +81,22 @@ class TestPayloadSerializer(unittest.TestCase):
             returned_reset_time, "Returned reset data time is not None.",
         )
 
-    def test_convert_to_model_1(self):
+    def test_convert_to_model(self):
         "Test serializer with full and valid payload turning to red status"
 
         full_payload_data = {
             "capacityStatus": self.capacity_status,
             "resetStatusIn": self.reset_status_in,
             "notes": self.notes,
+        }
+
+        context = {
             "apiUsername": self.api_username,
+            "apiUserId": self.api_user_id,
         }
 
         request_payload_serializer = CapacityStatusRequestPayloadSerializer(
-            data=full_payload_data
+            data=full_payload_data, context=context
         )
         request_payload_serializer.is_valid()
         model_data = request_payload_serializer.convertToModel(full_payload_data)
@@ -126,6 +131,12 @@ class TestPayloadSerializer(unittest.TestCase):
             model_data["notes"],
             "RAG status set by Capacity Service API - Additional notes",
             "Model notes data incorrectly set",
+        )
+
+        self.assertEqual(
+            model_data["modifiedbyid"],
+            self.api_user_id,
+            "Model modified by id incorrectly set",
         )
 
         self.assertEqual(

--- a/application/api/capacityservice/tests/test_serializers/test_payload_serializer.py
+++ b/application/api/capacityservice/tests/test_serializers/test_payload_serializer.py
@@ -100,3 +100,95 @@ class TestPayloadSerializer(unittest.TestCase):
             current_time + timedelta(minutes=-1),
             "Model modified date is a value less than expected",
         )
+
+    def test_to_internal_value_green_1(self):
+        "Test serializer with a GREEN capacity status and a set resetStatusIn time"
+
+        payload = {
+            "capacityStatus": "green",
+            "resetStatusIn": 500,
+        }
+
+        request_payload_serializer = CapacityStatusRequestPayloadSerializer(
+            data=payload
+        )
+        request_payload_serializer.is_valid()
+        validated_data = request_payload_serializer.validated_data
+
+        self.assertEqual(
+            validated_data["resetStatusIn"],
+            0,
+            "The resetStatusIn value should be 0 for a GREEN capacity status",
+        )
+        self.assertEqual(
+            validated_data["capacityStatus"],
+            "GREEN",
+            "The capacity status should be GREEN",
+        )
+
+    def test_to_internal_value_green_2(self):
+        "Test serializer with a GREEN capacity status and no resetStatusIn time"
+
+        payload = {"capacityStatus": "green"}
+
+        request_payload_serializer = CapacityStatusRequestPayloadSerializer(
+            data=payload
+        )
+        request_payload_serializer.is_valid()
+        validated_data = request_payload_serializer.validated_data
+
+        self.assertEqual(
+            validated_data["resetStatusIn"],
+            0,
+            "The resetStatusIn value should be 0 for a GREEN capacity status",
+        )
+        self.assertEqual(
+            validated_data["capacityStatus"],
+            "GREEN",
+            "The capacity status should be GREEN",
+        )
+
+    def test_to_internal_value_red_1(self):
+        "Test serializer with a RED capacity status and a set resetStatusIn time"
+
+        payload = {"capacityStatus": "red", "resetStatusIn": 500}
+
+        request_payload_serializer = CapacityStatusRequestPayloadSerializer(
+            data=payload
+        )
+        request_payload_serializer.is_valid()
+        validated_data = request_payload_serializer.validated_data
+
+        self.assertEqual(
+            validated_data["resetStatusIn"],
+            500,
+            "The resetStatusIn value should be 500 for a RED capacity status",
+        )
+        self.assertEqual(
+            validated_data["capacityStatus"],
+            "RED",
+            "The capacity status should be RED",
+        )
+
+    def test_to_internal_value_red_2(self):
+        "Test serializer with a RED capacity status and no resetStatusIn time"
+
+        payload = {"capacityStatus": "red"}
+
+        request_payload_serializer = CapacityStatusRequestPayloadSerializer(
+            data=payload
+        )
+        request_payload_serializer.is_valid()
+        validated_data = request_payload_serializer.validated_data
+
+        self.assertEqual(
+            validated_data["resetStatusIn"],
+            240,
+            "The resetStatusIn value should be 240 for a RED capacity status",
+        )
+        self.assertEqual(
+            validated_data["capacityStatus"],
+            "RED",
+            "The capacity status should be RED",
+        )
+

--- a/application/api/capacityservice/tests/test_serializers/test_payload_serializer.py
+++ b/application/api/capacityservice/tests/test_serializers/test_payload_serializer.py
@@ -12,7 +12,6 @@ class TestPayloadSerializer(unittest.TestCase):
     reset_status_in = 10
     notes = "Additional notes"
     api_username = "capApi"
-    api_user_id = 1234
 
     def test_reset_time_red(self):
         "Test reset_time method for RED status update"
@@ -88,15 +87,11 @@ class TestPayloadSerializer(unittest.TestCase):
             "capacityStatus": self.capacity_status,
             "resetStatusIn": self.reset_status_in,
             "notes": self.notes,
-        }
-
-        context = {
             "apiUsername": self.api_username,
-            "apiUserId": self.api_user_id,
         }
 
         request_payload_serializer = CapacityStatusRequestPayloadSerializer(
-            data=full_payload_data, context=context
+            data=full_payload_data
         )
         request_payload_serializer.is_valid()
         model_data = request_payload_serializer.convertToModel(full_payload_data)
@@ -131,12 +126,6 @@ class TestPayloadSerializer(unittest.TestCase):
             model_data["notes"],
             "RAG status set by Capacity Service API - Additional notes",
             "Model notes data incorrectly set",
-        )
-
-        self.assertEqual(
-            model_data["modifiedbyid"],
-            self.api_user_id,
-            "Model modified by id incorrectly set",
         )
 
         self.assertEqual(

--- a/application/api/capacityservice/tests/test_serializers/test_payload_serializer.py
+++ b/application/api/capacityservice/tests/test_serializers/test_payload_serializer.py
@@ -13,18 +13,23 @@ class TestPayloadSerializer(unittest.TestCase):
     notes = "Additional notes"
     api_username = "capApi"
 
-    def test_reset_time(self):
-        "Test reset_time method"
+    def test_reset_time_1(self):
+        "Test reset_time method for RED status update"
 
+        payload_data = {
+            "capacityStatus": self.capacity_status,
+            "resetStatusIn": 300,
+        }
         current_time = datetime.now()
-        reset_time_in = 300
-        expected_reset_time = current_time + timedelta(minutes=reset_time_in)
+        expected_reset_time = current_time + timedelta(
+            minutes=payload_data["resetStatusIn"]
+        )
         expected_reset_time_str = expected_reset_time.astimezone().strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         )
 
         returned_reset_time = CapacityStatusRequestPayloadSerializer._resetTime(
-            self, current_time, reset_time_in
+            self, current_time, payload_data
         )
 
         self.assertEqual(
@@ -33,8 +38,50 @@ class TestPayloadSerializer(unittest.TestCase):
             "Returned reset data time is not as expected.",
         )
 
+    def test_reset_time_2(self):
+        "Test reset_time method for AMBER status update"
+
+        payload_data = {
+            "capacityStatus": "AMBER",
+            "resetStatusIn": 300,
+        }
+        current_time = datetime.now()
+        expected_reset_time = current_time + timedelta(
+            minutes=payload_data["resetStatusIn"]
+        )
+        expected_reset_time_str = expected_reset_time.astimezone().strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+        returned_reset_time = CapacityStatusRequestPayloadSerializer._resetTime(
+            self, current_time, payload_data
+        )
+
+        self.assertEqual(
+            returned_reset_time,
+            expected_reset_time_str,
+            "Returned reset data time is not as expected.",
+        )
+
+    def test_reset_time_3(self):
+        "Test reset_time method for GREEN status update"
+
+        payload_data = {
+            "capacityStatus": "GREEN",
+            "resetStatusIn": 300,
+        }
+        current_time = datetime.now()
+
+        returned_reset_time = CapacityStatusRequestPayloadSerializer._resetTime(
+            self, current_time, payload_data
+        )
+
+        self.assertIsNone(
+            returned_reset_time, "Returned reset data time is not None.",
+        )
+
     def test_convert_to_model_1(self):
-        "Test serializer with full and valid payload"
+        "Test serializer with full and valid payload turning to red status"
 
         full_payload_data = {
             "capacityStatus": self.capacity_status,
@@ -100,95 +147,3 @@ class TestPayloadSerializer(unittest.TestCase):
             current_time + timedelta(minutes=-1),
             "Model modified date is a value less than expected",
         )
-
-    def test_to_internal_value_green_1(self):
-        "Test serializer with a GREEN capacity status and a set resetStatusIn time"
-
-        payload = {
-            "capacityStatus": "green",
-            "resetStatusIn": 500,
-        }
-
-        request_payload_serializer = CapacityStatusRequestPayloadSerializer(
-            data=payload
-        )
-        request_payload_serializer.is_valid()
-        validated_data = request_payload_serializer.validated_data
-
-        self.assertEqual(
-            validated_data["resetStatusIn"],
-            0,
-            "The resetStatusIn value should be 0 for a GREEN capacity status",
-        )
-        self.assertEqual(
-            validated_data["capacityStatus"],
-            "GREEN",
-            "The capacity status should be GREEN",
-        )
-
-    def test_to_internal_value_green_2(self):
-        "Test serializer with a GREEN capacity status and no resetStatusIn time"
-
-        payload = {"capacityStatus": "green"}
-
-        request_payload_serializer = CapacityStatusRequestPayloadSerializer(
-            data=payload
-        )
-        request_payload_serializer.is_valid()
-        validated_data = request_payload_serializer.validated_data
-
-        self.assertEqual(
-            validated_data["resetStatusIn"],
-            0,
-            "The resetStatusIn value should be 0 for a GREEN capacity status",
-        )
-        self.assertEqual(
-            validated_data["capacityStatus"],
-            "GREEN",
-            "The capacity status should be GREEN",
-        )
-
-    def test_to_internal_value_red_1(self):
-        "Test serializer with a RED capacity status and a set resetStatusIn time"
-
-        payload = {"capacityStatus": "red", "resetStatusIn": 500}
-
-        request_payload_serializer = CapacityStatusRequestPayloadSerializer(
-            data=payload
-        )
-        request_payload_serializer.is_valid()
-        validated_data = request_payload_serializer.validated_data
-
-        self.assertEqual(
-            validated_data["resetStatusIn"],
-            500,
-            "The resetStatusIn value should be 500 for a RED capacity status",
-        )
-        self.assertEqual(
-            validated_data["capacityStatus"],
-            "RED",
-            "The capacity status should be RED",
-        )
-
-    def test_to_internal_value_red_2(self):
-        "Test serializer with a RED capacity status and no resetStatusIn time"
-
-        payload = {"capacityStatus": "red"}
-
-        request_payload_serializer = CapacityStatusRequestPayloadSerializer(
-            data=payload
-        )
-        request_payload_serializer.is_valid()
-        validated_data = request_payload_serializer.validated_data
-
-        self.assertEqual(
-            validated_data["resetStatusIn"],
-            240,
-            "The resetStatusIn value should be 240 for a RED capacity status",
-        )
-        self.assertEqual(
-            validated_data["capacityStatus"],
-            "RED",
-            "The capacity status should be RED",
-        )
-


### PR DESCRIPTION
This PR ensures that the reset status time is always set to 0 (now) when updating to a green capacity state.