### PR TITLE
Adds admin UI active DoS user check

### DIFF
--- a/application/api/capacityauth/models.py
+++ b/application/api/capacityauth/models.py
@@ -21,7 +21,7 @@ class DosUserAPIKey(AbstractAPIKey):
             user = get_dos_user_for_username(str(value))
             logger.debug("DoS user exists with values: %s", user)
             if user.status != "ACTIVE":
-                raise ValidationError
+                raise ValidationError(
                     "Username '%(value)s' is not an 'ACTIVE' DoS user",
                     params={"value": value},
                 )

--- a/application/api/capacityauth/models.py
+++ b/application/api/capacityauth/models.py
@@ -20,6 +20,11 @@ class DosUserAPIKey(AbstractAPIKey):
         try:
             user = get_dos_user_for_username(str(value))
             logger.debug("DoS user exists with values: %s", user)
+            if user.status != "ACTIVE":
+                raise ValidationError
+                    "Username '%(value)s' is not an 'ACTIVE' DoS user",
+                    params={"value": value},
+                )
         except ObjectDoesNotExist:
             raise ValidationError(
                 "Username '%(value)s' does not exist in DoS", params={"value": value}


### PR DESCRIPTION
Note this is just the implementation of a check in the admin UI for when creating a Capacity API Key. It checks that a specified DoS Username is a user with an Active status. 

Comes with no unit tests as the current Capacity Auth Django app unit tests need reworking, and unit test for this work will be done as part of that reworking.

Therefore the review of this ticket will need to manual check this change via the admin UI for creating a Capacity Auth API key.