### PR TITLE
Overkill implementation to get 401 for bad key

### DIFF
--- a/application/api/capacityauth/authentication.py
+++ b/application/api/capacityauth/authentication.py
@@ -1,0 +1,92 @@
+from abc import ABC, abstractclassmethod
+from django.core.exceptions import ValidationError
+from rest_framework.authentication import BaseAuthentication, exceptions
+from rest_framework.authentication import get_authorization_header
+from rest_framework_api_key.models import AbstractAPIKey, APIKey
+from .models import DosUserAPIKey
+
+
+class AbstractAPIKeyAuthentication(BaseAuthentication, ABC):
+    """
+    Simple Abstract API Key based authentication, that needs to be extended by
+    a Authenticator class for the key class it's expect to handle e.g. APIKey.
+    Clients should authenticate by passing the API key in the "Authorization"
+    HTTP header, prepended with the string "Api-Key".  For example:
+        Authorization: Api-Key Pa5YxY4M.SSEHlZALYfBiPPVd6d6lGOIavS9kuybr
+
+    """
+
+    keyword = "Api-Key"
+    model_class = DosUserAPIKey
+    model = None
+
+    @abstractclassmethod
+    def get_model_class(self):
+        """Abstract get_model_class needs to return a class that extends the AbstractAPIKey class"""
+        return AbstractAPIKey
+
+    def get_model(self):
+        if self.model is not None:
+            return self.model
+
+        return self.model_class
+
+    def authenticate(self, request):
+        auth = get_authorization_header(request).split()
+
+        if not auth or auth[0].lower() != self.keyword.lower().encode():
+            return None
+
+        if len(auth) == 1:
+            msg = "Invalid Api-Key header. No credentials provided."
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = "Invalid Api-Key header. Key string should not contain spaces."
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            api_key = auth[1].decode()
+        except UnicodeError:
+            msg = "Invalid Api-Key header. key string should not contain invalid characters."
+
+            raise exceptions.AuthenticationFailed(msg)
+
+        return self.authenticate_credentials(api_key)
+
+    def authenticate_credentials(self, key):
+        model = self.get_model()
+        print("KEY:" + key)
+        print("IS VALID KEY: " + str(model.objects.is_valid(key)))
+        if not model.objects.is_valid(key):
+            raise exceptions.AuthenticationFailed("Invalid API key.")
+
+        return (None, key)
+
+    def authenticate_header(self, request):
+        return self.keyword
+
+
+class APIKeyAuthentication(AbstractAPIKeyAuthentication):
+    """
+    Simple API Key based authentication for handling APIKey instances.
+    Clients should authenticate by passing the API key in the "Authorization"
+    HTTP header, prepended with the string "Api-Key".  For example:
+        Authorization: Api-Key Pa5YxY4M.SSEHlZALYfBiPPVd6d6lGOIavS9kuybr
+
+    """
+
+    def get_model_class(self):
+        return APIKey
+
+
+class DosUserAPIKeyAuthentication(AbstractAPIKeyAuthentication):
+    """
+    Simple API Key based authentication for handling DosUserAPIKey instances.
+    Clients should authenticate by passing the API key in the "Authorization"
+    HTTP header, prepended with the string "Api-Key".  For example:
+        Authorization: Api-Key Pa5YxY4M.SSEHlZALYfBiPPVd6d6lGOIavS9kuybr
+
+    """
+
+    def get_model_class(self):
+        return DosUserAPIKey

--- a/application/api/capacityauth/authentication.py
+++ b/application/api/capacityauth/authentication.py
@@ -55,8 +55,6 @@ class AbstractAPIKeyAuthentication(BaseAuthentication, ABC):
 
     def authenticate_credentials(self, key):
         model = self.get_model()
-        print("KEY:" + key)
-        print("IS VALID KEY: " + str(model.objects.is_valid(key)))
         if not model.objects.is_valid(key):
             raise exceptions.AuthenticationFailed("Invalid API key.")
 

--- a/application/api/capacityservice/views.py
+++ b/application/api/capacityservice/views.py
@@ -2,6 +2,7 @@ from django.http import HttpResponse
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.authentication import TokenAuthentication
 
 from drf_yasg.utils import swagger_auto_schema
 
@@ -14,6 +15,7 @@ from .serializers.payload_serializer import CapacityStatusRequestPayloadSerializ
 from .serializers.response_serializer import CapacityStatusResponseSerializer
 
 from .models import ServiceCapacities
+from api.capacityauth.authentication import DosUserAPIKeyAuthentication
 from api.capacityauth.permissions import HasDosUserAPIKey
 
 from api.capacityauth.authorise import (
@@ -35,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class CapacityStatusView(RetrieveUpdateAPIView):
+    authentication_classes = [DosUserAPIKeyAuthentication]
     permission_classes = [HasDosUserAPIKey]
     queryset = ServiceCapacities.objects.db_manager("dos").all()
     serializer_class = CapacityStatusModelSerializer


### PR DESCRIPTION
> Implements an authentication class for API keys, so they are error-ed as 401 Unauthorised instead of 403 Forbidden. Currently the implementation is excessive and means the API key is being check both as part of authentication and authorization (permissions). 