### PR TITLE
Refactored AWS Secret Store strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,8 @@ project-deploy:
 	echo "The URL is $(UI_URL)"
 
 project-populate-secret-variables:
-	echo "export API_DB_PASSWORD=$$(make -s aws-secret-get NAME=capacity-status-api-dev-api-db-password)"
-	echo "export DOS_DB_PASSWORD=$$(make -s aws-secret-get NAME=capacity-status-api-dev-dos-db-dos-password)"
-	echo "export APP_ADMIN_PASSWORD=$$(make -s aws-secret-get NAME=capacity-status-api-admin-password)"
+	make secret-fetch-and-export-variables NAME=uec-dos-api-capacity-status-dev
+
 
 # ==============================================================================
 

--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -3,14 +3,12 @@
 # ==============================================================================
 # Service variables
 
-API_DB_HOST := uec-dos-api-cs-nonprod-db.cqger35bxcwy.eu-west-2.rds.amazonaws.com # TODO: Let's move it to the Secret Manager
 API_DB_NAME := capacity_status
 API_DB_PORT := 5432
 API_DB_USERNAME := postgres
 API_LOG_LEVEL := INFO
 
-DOS_DB_HOST := uec-dos-api-cs-nonprod-db.cqger35bxcwy.eu-west-2.rds.amazonaws.com # TODO: Let's move it to the Secret Manager
-DOS_DB_NAME := postgres
+DOS_DB_NAME := pathwaysdos_test
 DOS_DB_PORT := 5432
 DOS_DB_USERNAME := postgres
 


### PR DESCRIPTION
This PR refactors our AWS Secret Store strategy in that we now store all secrets associated with the Capacity Status API in one Secret Store.  The Secret Store contains all the secret information the application requires in the form of key/value pairs.  This information is extracted from the secret store in the deployment process as part of the project-deploy make target.
Any additional secret information required can just be added to this secret store as another key/value pair.
Note that the handling of this extraction process is already handled in the common make code by the secret-fetch-and-export-variables make target. So for us, its just a case of calling this make target with the name of our secret store and creating the secret store in AWS.