### PR TITLE
Update regression tests for token auth

### DIFF
--- a/application/api/capacityauth/models.py
+++ b/application/api/capacityauth/models.py
@@ -40,7 +40,7 @@ class CapacityAuthDosUser(models.Model):
     )
     user = models.OneToOneField(User, on_delete=models.CASCADE)
 
-    def save(self):
+    def save(self, *args, **kwargs):
         self.dos_user_id = get_dos_user_for_username(self.dos_username).id
         return super().save()
 

--- a/application/api/capacityservice/tests/test_regression/get_endpoint/test_get_404.py
+++ b/application/api/capacityservice/tests/test_regression/get_endpoint/test_get_404.py
@@ -11,7 +11,7 @@ class TestGet404(unittest.TestCase):
 
     def test_no_service_found(self):
         response = self.client.get(
-            TestEnv.api_no_service_url, HTTP_HOST="127.0.0.1", **TestEnv.auth_headers,
+            TestEnv.api_no_service_url, HTTP_HOST=TestEnv.api_host, **TestEnv.auth_headers,
         )
 
         self.assertEqual(
@@ -24,7 +24,7 @@ class TestGet404(unittest.TestCase):
     def test_inactive_service_found(self):
         response = self.client.get(
             TestEnv.api_inactive_service_url,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 

--- a/application/api/capacityservice/tests/test_regression/get_endpoint/test_get_authentication.py
+++ b/application/api/capacityservice/tests/test_regression/get_endpoint/test_get_authentication.py
@@ -10,10 +10,10 @@ class TestGetAuthentication(unittest.TestCase):
     client = Client()
 
     def test_unauthorised_user_no_creds(self):
-        response = self.client.get(TestEnv.api_url)
+        response = self.client.get(TestEnv.api_url, HTTP_HOST=TestEnv.api_host,)
 
         self.assertEqual(
-            response.status_code, 403, "Response status code is not as expected."
+            response.status_code, 401, "Response status code is not as expected."
         )
         self.assertEqual(
             response.content,
@@ -23,21 +23,21 @@ class TestGetAuthentication(unittest.TestCase):
 
     def test_unauthorised_user_invalid_creds(self):
         response = self.client.get(
-            TestEnv.api_url, HTTP_HOST="127.0.0.1", **TestEnv.invalid_auth_headers
+            TestEnv.api_url, HTTP_HOST=TestEnv.api_host, **TestEnv.invalid_auth_headers
         )
 
         self.assertEqual(
-            response.status_code, 403, "Response status code is not as expected."
+            response.status_code, 401, "Response status code is not as expected."
         )
         self.assertEqual(
             response.content,
-            b'{"detail":"Authentication credentials were not provided."}',
+            b'{"detail":"Invalid token."}',
             "Response message is not as expected.",
         )
 
     def test_user_not_active(self):
         response = self.client.get(
-            TestEnv.api_url, HTTP_HOST="127.0.0.1", **TestEnv.inactive_auth_headers
+            TestEnv.api_url, HTTP_HOST=TestEnv.api_host, **TestEnv.inactive_auth_headers
         )
 
         self.assertEqual(

--- a/application/api/capacityservice/tests/test_regression/get_endpoint/test_get_success.py
+++ b/application/api/capacityservice/tests/test_regression/get_endpoint/test_get_success.py
@@ -12,7 +12,7 @@ class TestGetSuccess(unittest.TestCase):
 
     def test_get_success(self):
         response = self.client.get(
-            TestEnv.api_unauthorised_url, HTTP_HOST="127.0.0.1", **TestEnv.auth_headers
+            TestEnv.api_unauthorised_url, HTTP_HOST=TestEnv.api_host, **TestEnv.auth_headers
         )
         json_response = json.loads(str(response.content, encoding="utf8"))
 

--- a/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_404.py
+++ b/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_404.py
@@ -9,7 +9,7 @@ class TestPatch404(unittest.TestCase):
     def test_no_service_found(self):
         client = Client()
         response = client.patch(
-            TestEnv.api_no_service_url, HTTP_HOST="127.0.0.1", **TestEnv.auth_headers
+            TestEnv.api_no_service_url, HTTP_HOST=TestEnv.api_host, **TestEnv.auth_headers
         )
 
         self.assertEqual(
@@ -23,7 +23,7 @@ class TestPatch404(unittest.TestCase):
         client = Client()
         response = client.patch(
             TestEnv.api_inactive_service_url,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 

--- a/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_authentication.py
+++ b/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_authentication.py
@@ -9,10 +9,10 @@ class TestPatchAuthentication(unittest.TestCase):
     client = Client()
 
     def test_unauthorised_user_no_creds(self):
-        response = self.client.patch(TestEnv.api_url)
+        response = self.client.patch(TestEnv.api_url, HTTP_HOST=TestEnv.api_host,)
 
         self.assertEqual(
-            response.status_code, 403, "Response status code is not as expected."
+            response.status_code, 401, "Response status code is not as expected."
         )
         self.assertEqual(
             response.content,
@@ -22,23 +22,22 @@ class TestPatchAuthentication(unittest.TestCase):
 
     def test_unauthorised_user_invalid_creds(self):
         response = self.client.patch(
-            TestEnv.api_url, HTTP_HOST="127.0.0.1", **TestEnv.invalid_auth_headers
+            TestEnv.api_url, HTTP_HOST=TestEnv.api_host, **TestEnv.invalid_auth_headers
         )
 
         self.assertEqual(
-            response.status_code, 403, "Response status code is not as expected."
+            response.status_code, 401, "Response status code is not as expected."
         )
         self.assertEqual(
             response.content,
-            b'{"detail":"Authentication credentials were not provided."}',
+            b'{"detail":"Invalid token."}',
             "Response message is not as expected.",
         )
 
     def test_user_not_active(self):
         response = self.client.patch(
-            TestEnv.api_url, HTTP_HOST="127.0.0.1", **TestEnv.inactive_auth_headers
+            TestEnv.api_url, HTTP_HOST=TestEnv.api_host, **TestEnv.inactive_auth_headers
         )
-
         self.assertEqual(
             response.status_code, 401, "Response status code is not as expected."
         )

--- a/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_authorisation.py
+++ b/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_authorisation.py
@@ -16,7 +16,7 @@ class TestPatchView(unittest.TestCase):
             TestEnv.api_unauthorised_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 

--- a/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_success.py
+++ b/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_success.py
@@ -21,7 +21,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
         json_response = json.loads(str(response.content, encoding="utf8"))
@@ -40,7 +40,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
         json_response = json.loads(str(response.content, encoding="utf8"))
@@ -61,7 +61,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
         json_response = json.loads(str(response.content, encoding="utf8"))
@@ -85,7 +85,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
         json_response = json.loads(str(response.content, encoding="utf8"))
@@ -108,7 +108,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
         json_response = json.loads(str(response.content, encoding="utf8"))
@@ -132,7 +132,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -152,7 +152,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -172,7 +172,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -192,7 +192,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -214,7 +214,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -243,7 +243,7 @@ class TestPatchSuccess(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 

--- a/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_validation.py
+++ b/application/api/capacityservice/tests/test_regression/patch_endpoint/test_patch_validation.py
@@ -16,7 +16,7 @@ class TestPatchValidationVal0001(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -42,7 +42,7 @@ class TestPatchValidationVal0002(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -64,7 +64,7 @@ class TestPatchValidationVal0002(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -86,7 +86,7 @@ class TestPatchValidationVal0002(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -113,7 +113,7 @@ class TestPatchValidationVal0003(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -136,7 +136,7 @@ class TestPatchValidationVal0003(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -163,7 +163,7 @@ class TestPatchValidationVal0004(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -186,7 +186,7 @@ class TestPatchValidationVal0004(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -219,7 +219,7 @@ class TestPatchValidationVal0005(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -246,7 +246,7 @@ class TestPatchValidationVal0006(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 
@@ -274,7 +274,7 @@ class TestPatchValidationMultipleVals(unittest.TestCase):
             TestEnv.api_url,
             content_type="application/json",
             data=data,
-            HTTP_HOST="127.0.0.1",
+            HTTP_HOST=TestEnv.api_host,
             **TestEnv.auth_headers,
         )
 

--- a/application/api/capacityservice/tests/test_regression/test_env.py
+++ b/application/api/capacityservice/tests/test_regression/test_env.py
@@ -1,54 +1,62 @@
 from django.core.exceptions import ObjectDoesNotExist
+from rest_framework.authtoken.models import Token
+from django.contrib.auth.models import User
 from datetime import datetime, timedelta
 
-from ....capacityauth.models import DosUserAPIKey
-
+from api.capacityauth.models import CapacityAuthDosUser
 
 class TestEnv:
+    api_host = "localhost"
     api_url = "/api/v0.0.1/capacity/services/149198/capacitystatus/"
     api_no_service_url = "/api/v0.0.1/capacity/services/1491981234/capacitystatus/"
     api_inactive_service_url = "/api/v0.0.1/capacity/services/133102/capacitystatus/"
     api_unauthorised_url = "/api/v0.0.1/capacity/services/110798/capacitystatus/"
-    api_key = None
+
+    token_key = None
     auth_headers = None
     key = None
     inactive_key = None
     try:
-        key = (
-            DosUserAPIKey.objects.db_manager("default")
-            .filter(dos_username__contains="TestUser")
+        user = (
+            User.objects.db_manager("default")
+            .filter(username__contains="TestUser")
             .delete()
         )
     except ObjectDoesNotExist:
         pass
     finally:
-        key = DosUserAPIKey.objects.db_manager("default").create_key(
-            dos_username="TestUser"
-        )
+
+        user = (User.objects.db_manager("default").create_user(username="TestUser",
+        password="fakePassword1"))
+        ca_dos_user = (CapacityAuthDosUser.objects.db_manager("default")
+            .create(dos_username="TestUser", dos_user_id=1000000002, user=user))
+        token = (Token.objects.db_manager("default").create(user=user))
 
     try:
-        inactive_key = (
-            DosUserAPIKey.objects.db_manager("default")
-            .filter(dos_username__contains="InActiveTestUser")
-            .delete()
-        )
+
+        inactive_user = (
+            User.objects.db_manager("default")
+            .filter(username__contains="InActiveTestUser")
+            .delete())
     except ObjectDoesNotExist:
         pass
     finally:
-        inactive_key = DosUserAPIKey.objects.db_manager("default").create_key(
-            dos_username="InActiveTestUser"
-        )
+        inactive_user = (User.objects.db_manager("default")
+            .create_user(username="InActiveTestUser", password="fakePassword2"))
+        ca_dos_user = (CapacityAuthDosUser.objects.db_manager("default")
+            .create(dos_username="InActiveTestUser", dos_user_id=1000000003,
+            user=inactive_user))
+        inactive_token = (Token.objects.db_manager("default").create(user=inactive_user))
 
-    api_key = key[1]
+
     auth_headers = {
-        "HTTP_AUTHORIZATION": "Api-Key " + api_key,
+        "HTTP_AUTHORIZATION": "Token " + token.key,
     }
-    inactive_api_key = inactive_key[1]
     inactive_auth_headers = {
-        "HTTP_AUTHORIZATION": "Api-Key " + inactive_api_key,
+        "HTTP_AUTHORIZATION": "Token " + inactive_token.key,
     }
     invalid_auth_headers = {
-        "HTTP_AUTHORIZATION": "Api-Key Invalid",
+        "HTTP_AUTHORIZATION": "Token Invalid",
     }
 
     current_time = datetime.now()

--- a/application/api/capacityservice/views.py
+++ b/application/api/capacityservice/views.py
@@ -2,7 +2,6 @@ from django.http import HttpResponse
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.authentication import TokenAuthentication
 
 from drf_yasg.utils import swagger_auto_schema
 
@@ -34,7 +33,6 @@ logger = logging.getLogger(__name__)
 
 
 class CapacityStatusView(RetrieveUpdateAPIView):
-    authentication_classes = [TokenAuthentication]
     queryset = ServiceCapacities.objects.db_manager("dos").all()
     serializer_class = CapacityStatusModelSerializer
     lookup_field = "service__uid"

--- a/application/api/settings.py
+++ b/application/api/settings.py
@@ -173,6 +173,14 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ]
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/


### PR DESCRIPTION
This piece of work updates the regression tests to use and validate the Token based authentication.

In the course of working on this issue a bug was found by the tests, where token authentication can be effectively skip if an auth header is not specified. This has also been fixed in this branch by using the IsAuthenticated permission class.