### PR TITLE
Refine coverage make target

### DIFF
--- a/application/Makefile
+++ b/application/Makefile
@@ -25,7 +25,8 @@ test: clean # Run the test suite
 	python manage.py test api/capacityservice/ api/dos/
 
 coverage: clean # View a report on test coverage
-	coverage run --source='.' manage.py test api/capacityservice/ api/dos/
+	coverage run --source='.' --omit=*/tests/*,*/migrations/* \
+	 manage.py test api/
 	coverage report -m
 	coverage erase
 

--- a/application/Makefile
+++ b/application/Makefile
@@ -26,7 +26,7 @@ test: clean # Run the test suite
 
 coverage: clean # View a report on test coverage
 	coverage run --source='.' --omit=*/tests/*,*/migrations/*,*apps.py,*asgi.py,*wsgi.py \
-	manage.py test api/
+		manage.py test api/
 	coverage report -m
 	coverage erase
 

--- a/application/Makefile
+++ b/application/Makefile
@@ -25,8 +25,8 @@ test: clean # Run the test suite
 	python manage.py test api/capacityservice/ api/dos/
 
 coverage: clean # View a report on test coverage
-	coverage run --source='.' --omit=*/tests/*,*/migrations/* \
-	 manage.py test api/
+	coverage run --source='.' --omit=*/tests/*,*/migrations/*,*apps.py,*asgi.py,*wsgi.py \
+	manage.py test api/
 	coverage report -m
 	coverage erase
 


### PR DESCRIPTION
Makes edits to the Coverage make target to omit certain files (include the tests) from being check for test coverage. The change also makes sure all of the tests are run as part of the coverage check.