### PR TITLE
Test and coverage reporting improvements

### DIFF
--- a/application/Makefile
+++ b/application/Makefile
@@ -30,6 +30,18 @@ coverage: clean # View a report on test coverage
 	coverage report -m
 	coverage erase
 
+unit-test-coverage: clean # View a report on test coverage
+	coverage run --source='.' --omit=*/tests/*,*/migrations/*,*apps.py,*asgi.py,*wsgi.py \
+		manage.py test api/ --exclude-tag=regression
+	coverage report -m
+	coverage erase
+
+regression-test-coverage: clean # View a report on test coverage
+	coverage run --source='.' --omit=*/tests/*,*/migrations/*,*apps.py,*asgi.py,*wsgi.py \
+		manage.py test api/ --tag=regression
+	coverage report -m
+	coverage erase
+
 tidy: clean # Tidy code with the 'black' formatte
 	@echo "\nTidying code with black..."
 	black -l 119 api

--- a/application/api/authentication/tests/test_admin.py
+++ b/application/api/authentication/tests/test_admin.py
@@ -25,9 +25,9 @@ class TestDosUserInline(TestCase):
         admin = DosUserInline(CapacityAuthDosUser, mock_admin)
         dummy_request = "dummy-request"
         dummy_object = "dummy-object"
-        mock_super().get_exclude.return_value = None
+        mock_super().get_exclude.return_value = ["fake_exclude_field",]
 
         exclude = admin.get_exclude(dummy_request, dummy_object)
 
         mock_super().get_exclude.assert_called_with(dummy_request, dummy_object)
-        self.assertListEqual(["dos_user_id",], exclude)
+        self.assertListEqual(["fake_exclude_field","dos_user_id",], exclude)

--- a/application/api/dos_interface/tests/test_queries.py
+++ b/application/api/dos_interface/tests/test_queries.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
-from ..queries import can_user_edit_service, Users
+from ..queries import can_user_edit_service, get_dos_service_for_uid, Users
 from ..models import Services
+from api.dos_interface.models import Services
 
 
 class TestCanUserEditService(TestCase):
@@ -82,6 +83,16 @@ class TestCanUserEditService(TestCase):
         dos_user_id = 1000000001
         user_can_edit = can_user_edit_service(dos_user_id, service_uid)
         self.assertFalse(user_can_edit)
+
+    def test_get_dos_service_for_uid__success(self):
+        "Test get_dos_service_for_uid, success"
+        service_uid = "149198"
+        service = get_dos_service_for_uid(service_uid)
+        self.assertIsInstance(service, Services)
+        self.assertEqual(service.uid, service_uid)
+        self.assertIsNotNone(service.name)
+        self.assertNotEqual(service.name, "")
+
 
     # Re-activate users & services
     def tearDown(self):

--- a/application/api/service/tests/test_regression/get_endpoint/test_get_404.py
+++ b/application/api/service/tests/test_regression/get_endpoint/test_get_404.py
@@ -1,9 +1,9 @@
 import unittest
-from django.test import Client
+from django.test import Client, tag
 
 from ..test_env import TestEnv
 
-
+@tag("regression")
 class TestGet404(unittest.TestCase):
     "Tests the service not found scenario for the GET endpoint"
 

--- a/application/api/service/tests/test_regression/get_endpoint/test_get_authentication.py
+++ b/application/api/service/tests/test_regression/get_endpoint/test_get_authentication.py
@@ -1,9 +1,9 @@
 import unittest
-from django.test import Client
+from django.test import Client, tag
 
 from ..test_env import TestEnv
 
-
+@tag("regression")
 class TestGetAuthentication(unittest.TestCase):
     "Tests authentication for the Get endpoint"
 

--- a/application/api/service/tests/test_regression/get_endpoint/test_get_success.py
+++ b/application/api/service/tests/test_regression/get_endpoint/test_get_success.py
@@ -1,10 +1,10 @@
 import unittest
 import json
-from django.test import Client
+from django.test import Client, tag
 
 from ..test_env import TestEnv
 
-
+@tag("regression")
 class TestGetSuccess(unittest.TestCase):
     "Tests success scenarios for the Get endpoint"
 

--- a/application/api/service/tests/test_regression/patch_endpoint/test_patch_404.py
+++ b/application/api/service/tests/test_regression/patch_endpoint/test_patch_404.py
@@ -1,8 +1,8 @@
 import unittest
-from django.test import Client
+from django.test import Client, tag
 from ..test_env import TestEnv
 
-
+@tag("regression")
 class TestPatch404(unittest.TestCase):
     "Tests for handling service not found scenario for the PATCH endpoint"
 

--- a/application/api/service/tests/test_regression/patch_endpoint/test_patch_authentication.py
+++ b/application/api/service/tests/test_regression/patch_endpoint/test_patch_authentication.py
@@ -1,8 +1,8 @@
 import unittest
-from django.test import Client
+from django.test import Client, tag
 from ..test_env import TestEnv
 
-
+@tag("regression")
 class TestPatchAuthentication(unittest.TestCase):
     "Tests for authentication scenarios for the Patch endpoint"
 

--- a/application/api/service/tests/test_regression/patch_endpoint/test_patch_authorisation.py
+++ b/application/api/service/tests/test_regression/patch_endpoint/test_patch_authorisation.py
@@ -1,9 +1,9 @@
 import unittest
 import json
-from django.test import Client
+from django.test import Client, tag
 from ..test_env import TestEnv
 
-
+@tag("regression")
 class TestPatchView(unittest.TestCase):
     "Tests authorisation for the PATCH endpoint."
 

--- a/application/api/service/tests/test_regression/patch_endpoint/test_patch_success.py
+++ b/application/api/service/tests/test_regression/patch_endpoint/test_patch_success.py
@@ -2,14 +2,14 @@ import unittest
 import json
 from datetime import datetime, timedelta
 
-from django.test import Client
+from django.test import Client, tag
 from ..test_env import TestEnv
 from ..test_helper import TestHelper
 
 test_helper = TestHelper()
 client = Client()
 
-
+@tag("regression")
 class TestPatchSuccess(unittest.TestCase):
     "Tests for the successful update of capacity status information"
 

--- a/application/api/service/tests/test_regression/patch_endpoint/test_patch_validation.py
+++ b/application/api/service/tests/test_regression/patch_endpoint/test_patch_validation.py
@@ -1,9 +1,9 @@
 import unittest
 import json
-from django.test import Client
+from django.test import Client, tag
 from ..test_env import TestEnv
 
-
+@tag("regression")
 class TestPatchValidationVal0001(unittest.TestCase):
     "Tests for the VAL-0001 validation code for the Patch endpoint"
 


### PR DESCRIPTION
This PR has changes to improve test coverage in the authentication and dos interface apps. It also adds improvements to test coverage reporting, by providing two new make targets to check unit tests and regression tests separately.