### PR TITLE
Create api role for connection to the DoS database

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,6 @@
 ## Other tasks
 
 - Security
-  - Create a new DB user in the DoS database only to be used by the API application to connect
   - API throttling (CSAPI-44)
 - Application
   - Let's revisit the domain model and consider again the naming of `serviceUid` (just `id`), `serviceName` (just `name`?), `capacityStatus` (just `status`?)
@@ -53,3 +52,4 @@
   - Configure Slack
 - Development
   - Externalise `flake8` and `black` configuration
+  - Consider renaming our development DoS DB to pathwaysdos to match the real version

--- a/application/api/dos_interface/reporting.py
+++ b/application/api/dos_interface/reporting.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from api.dos_interface.queries import get_service_info
 
-from datetime import datetime
+from datetime import datetime, timezone
 from time import gmtime, strftime
 
 import logging
@@ -42,7 +42,7 @@ def _retrieve_service_data(service_uid):
 
 def _get_request_execution_time(request):
     request_received = datetime.fromisoformat(request.META["HTTP_X_REQUEST_RECEIVED"])
-    return (datetime.now() - request_received).total_seconds()
+    return (datetime.now(timezone.utc) - request_received).total_seconds()
 
 
 def log_reporting_info(

--- a/application/api/settings.py
+++ b/application/api/settings.py
@@ -108,7 +108,7 @@ DATABASES = {
         "HOST": os.getenv("DOS_DB_HOST", "db-dos"),
         "PORT": os.getenv("DOS_DB_PORT", "5432"),
         "NAME": os.getenv("DOS_DB_NAME", "postgres"),
-        "USER": os.getenv("DOS_DB_USERNAME", "postgres"),
+        "USER": os.getenv("DOS_DB_USERNAME", "uec_dos_api_cs_role"),
         "PASSWORD": os.getenv("DOS_DB_PASSWORD", "postgres"),
     },
 }

--- a/application/api/settings.py
+++ b/application/api/settings.py
@@ -109,7 +109,7 @@ DATABASES = {
         "PORT": os.getenv("DOS_DB_PORT", "5432"),
         "NAME": os.getenv("DOS_DB_NAME", "postgres"),
         "USER": os.getenv("DOS_DB_USERNAME", "uec_dos_api_cs_role"),
-        "PASSWORD": os.getenv("DOS_DB_PASSWORD", "uec_dos_api_cs_role"),
+        "PASSWORD": os.getenv("DOS_DB_PASSWORD", "uec_dos_api_cs_role_db_password"),
     },
 }
 

--- a/application/api/settings.py
+++ b/application/api/settings.py
@@ -108,8 +108,8 @@ DATABASES = {
         "HOST": os.getenv("DOS_DB_HOST", "db-dos"),
         "PORT": os.getenv("DOS_DB_PORT", "5432"),
         "NAME": os.getenv("DOS_DB_NAME", "postgres"),
-        "USER": os.getenv("DOS_DB_USERNAME", "uec_dos_api_cs_role"),
-        "PASSWORD": os.getenv("DOS_DB_PASSWORD", "uec_dos_api_cs_role_db_password"),
+        "USER": os.getenv("DOS_DB_USERNAME", "capacity_status_api"),
+        "PASSWORD": os.getenv("DOS_DB_PASSWORD", "capacity_status_api"),
     },
 }
 

--- a/application/api/settings.py
+++ b/application/api/settings.py
@@ -109,7 +109,7 @@ DATABASES = {
         "PORT": os.getenv("DOS_DB_PORT", "5432"),
         "NAME": os.getenv("DOS_DB_NAME", "postgres"),
         "USER": os.getenv("DOS_DB_USERNAME", "uec_dos_api_cs_role"),
-        "PASSWORD": os.getenv("DOS_DB_PASSWORD", "postgres"),
+        "PASSWORD": os.getenv("DOS_DB_PASSWORD", "uec_dos_api_cs_role"),
     },
 }
 

--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -16,7 +16,7 @@ API_LOG_LEVEL = INFO
 #DOS_DB_HOST = [secret]
 DOS_DB_NAME = postgres
 DOS_DB_PORT = 5432
-DOS_DB_USERNAME = uec_dos_api_cs_role
+DOS_DB_USERNAME = capacity_status_api
 #DOS_DB_PASSWORD = [secret]
 
 #APP_ADMIN_PASSWORD = [secret]

--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -14,7 +14,7 @@ API_DB_USERNAME = postgres
 API_LOG_LEVEL = INFO
 
 #DOS_DB_HOST = [secret]
-DOS_DB_NAME = pathwaysdos_test
+DOS_DB_NAME = postgres
 DOS_DB_PORT = 5432
 DOS_DB_USERNAME = uec_dos_api_cs_role
 #DOS_DB_PASSWORD = [secret]

--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -16,7 +16,7 @@ API_LOG_LEVEL = INFO
 #DOS_DB_HOST = [secret]
 DOS_DB_NAME = pathwaysdos_test
 DOS_DB_PORT = 5432
-DOS_DB_USERNAME = postgres
+DOS_DB_USERNAME = uec_dos_api_cs_role
 #DOS_DB_PASSWORD = [secret]
 
 #APP_ADMIN_PASSWORD = [secret]

--- a/build/automation/var/profile/local.mk
+++ b/build/automation/var/profile/local.mk
@@ -16,8 +16,8 @@ API_LOG_LEVEL = DEBUG
 DOS_DB_HOST = db-dos
 DOS_DB_NAME = postgres
 DOS_DB_PORT = 5432
-DOS_DB_USERNAME = uec_dos_api_cs_role
-DOS_DB_PASSWORD = uec_dos_api_cs_role_db_password
+DOS_DB_USERNAME = capacity_status_api
+DOS_DB_PASSWORD = capacity_status_api
 
 APP_ADMIN_PASSWORD = admin
 

--- a/build/automation/var/profile/local.mk
+++ b/build/automation/var/profile/local.mk
@@ -17,7 +17,7 @@ DOS_DB_HOST = db-dos
 DOS_DB_NAME = postgres
 DOS_DB_PORT = 5432
 DOS_DB_USERNAME = uec_dos_api_cs_role
-DOS_DB_PASSWORD = postgres
+DOS_DB_PASSWORD = uec_dos_api_cs_role_db_password
 
 APP_ADMIN_PASSWORD = admin
 

--- a/build/automation/var/profile/local.mk
+++ b/build/automation/var/profile/local.mk
@@ -16,7 +16,7 @@ API_LOG_LEVEL = DEBUG
 DOS_DB_HOST = db-dos
 DOS_DB_NAME = postgres
 DOS_DB_PORT = 5432
-DOS_DB_USERNAME = postgres
+DOS_DB_USERNAME = uec_dos_api_cs_role
 DOS_DB_PASSWORD = postgres
 
 APP_ADMIN_PASSWORD = admin

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       DB_HOST: db-dos
       DB_PORT: 5432
       DB_NAME: postgres
-      DB_USERNAME: uec_dos_api_cs_role
-      DB_PASSWORD: postgres
+      DOS_DB_USERNAME: uec_dos_api_cs_role
+      DOS_DB_PASSWORD: uec_dos_api_cs_role_db_password
       APP_ADMIN_PASSWORD: admin
       DJANGO_DEBUG: "True"
       HTTP_PROTOCOL: https

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       DB_HOST: db-dos
       DB_PORT: 5432
       DB_NAME: postgres
-      DB_USERNAME: postgres
+      DB_USERNAME: uec_dos_api_cs_role
       DB_PASSWORD: postgres
       APP_ADMIN_PASSWORD: admin
       DJANGO_DEBUG: "True"

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       DB_HOST: db-dos
       DB_PORT: 5432
       DB_NAME: postgres
-      DOS_DB_USERNAME: uec_dos_api_cs_role
-      DOS_DB_PASSWORD: uec_dos_api_cs_role_db_password
+      DOS_DB_USERNAME: capacity_status_api
+      DOS_DB_PASSWORD: capacity_status_api
       APP_ADMIN_PASSWORD: admin
       DJANGO_DEBUG: "True"
       HTTP_PROTOCOL: https

--- a/build/docker/proxy/assets/etc/nginx/nginx.conf.template
+++ b/build/docker/proxy/assets/etc/nginx/nginx.conf.template
@@ -16,6 +16,16 @@ http {
                 ALLOWED_HOSTS_TO_REPLACE
     }
 
+    map $time_iso8601 $time_iso8601_p1 {
+      ~([^+]+) $1;
+    }
+    map $time_iso8601 $time_iso8601_p2 {
+      ~\+([0-9:]+)$ $1;
+    }
+    map $msec $millisec {
+      ~\.([0-9]+)$ $1;
+    }
+
     server {
         listen 443 ssl;
         server_name localhost;
@@ -50,7 +60,7 @@ http {
             proxy_set_header   X-Client-IP $http_x_forwarded_for;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Host $server_name;
-            proxy_set_header   X-Request-Received $time_local;
+            proxy_set_header   X-Request-Received $time_iso8601_p1.$millisec+$time_iso8601_p2;
         }
         location /health {
             return 200 'healthcheck success from proxy server';

--- a/data/aws-rds-sql/10-api-dos-db-role.sql
+++ b/data/aws-rds-sql/10-api-dos-db-role.sql
@@ -13,7 +13,7 @@ SET standard_conforming_strings = on;
 -- Roles
 --
 CREATE ROLE capacity_status_api;
-ALTER ROLE capacity_status_api WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS PASSWORD 'capacity_status_api';
+ALTER ROLE capacity_status_api INHERIT NOCREATEROLE NOCREATEDB LOGIN NOBYPASSRLS PASSWORD 'capacity_status_api';
 COMMENT ON ROLE capacity_status_api IS 'Accessor role to the DoS DB for the DoS Capacity Status API.';
 
 -- User Configurations

--- a/data/dos-import-db.sh
+++ b/data/dos-import-db.sh
@@ -19,3 +19,4 @@ psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME" -f data/a
 psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME" -f data/aws-rds-sql/07-create_test_user.sql
 psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME" -f data/aws-rds-sql/08-create_inactive_test_user.sql
 psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME" -f data/aws-rds-sql/09-assign_inactive_service_to_test_user.sql
+psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME" -f data/aws-rds-sql/10-api-dos-db-role.sql

--- a/data/sql/10-api-dos-db-role.sql
+++ b/data/sql/10-api-dos-db-role.sql
@@ -13,7 +13,7 @@ SET standard_conforming_strings = on;
 -- Roles
 --
 CREATE ROLE uec_dos_api_cs_role;
-ALTER ROLE uec_dos_api_cs_role WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS PASSWORD 'uec_dos_api_cs_role';
+ALTER ROLE uec_dos_api_cs_role WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS PASSWORD 'uec_dos_api_cs_role_db_password';
 COMMENT ON ROLE uec_dos_api_cs_role IS 'Accessor role to the DoS DB for the DoS Capacity Status API.';
 
 -- User Configurations

--- a/data/sql/10-api-dos-db-role.sql
+++ b/data/sql/10-api-dos-db-role.sql
@@ -23,4 +23,12 @@ COMMENT ON ROLE uec_dos_api_cs IS 'Accessor role for the DoS Capacity Status API
 
 ALTER ROLE CREATE ROLE uec_dos_api_cs_role; SET search_path TO 'pathwaysdos';
 
+-- Grant table permissions
 
+GRANT SELECT, UPDATE ON pathwaysdos.servicecapacities TO uec_dos_api_cs_role;
+
+GRANT SELECT ON pathwaysdos.users TO uec_dos_api_cs_role;
+GRANT SELECT ON pathwaysdos.userpermissions TO uec_dos_api_cs_role;
+GRANT SELECT ON pathwaysdos.userservices TO uec_dos_api_cs_role;
+GRANT SELECT ON pathwaysdos.capacitystatuses TO uec_dos_api_cs_role;
+GRANT SELECT ON pathwaysdos.services TO uec_dos_api_cs_role;

--- a/data/sql/10-api-dos-db-role.sql
+++ b/data/sql/10-api-dos-db-role.sql
@@ -1,0 +1,26 @@
+--
+-- This script will create a role that the Capacity Status API will use to connect to
+-- the DoS database. The role will consist of the minmimum amount of priviledges required
+-- in order for the API to retrieve and update the capacity status information of a
+-- service.
+--
+
+SET default_transaction_read_only = off;
+
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+
+--
+-- Roles
+--
+
+CREATE ROLE uec_dos_api_cs_role;
+ALTER ROLE uec_dos_api_cs WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS PASSWORD 'uec_dos_api_cs_role';
+COMMENT ON ROLE uec_dos_api_cs IS 'Accessor role for the DoS Capacity Status API.';
+
+-- User Configurations
+--
+
+ALTER ROLE CREATE ROLE uec_dos_api_cs_role; SET search_path TO 'pathwaysdos';
+
+

--- a/data/sql/10-api-dos-db-role.sql
+++ b/data/sql/10-api-dos-db-role.sql
@@ -4,7 +4,6 @@
 -- in order for the API to retrieve and update the capacity status information of a
 -- service.
 --
-
 SET default_transaction_read_only = off;
 
 SET client_encoding = 'UTF8';
@@ -13,18 +12,18 @@ SET standard_conforming_strings = on;
 --
 -- Roles
 --
-
 CREATE ROLE uec_dos_api_cs_role;
-ALTER ROLE uec_dos_api_cs WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS PASSWORD 'uec_dos_api_cs_role';
-COMMENT ON ROLE uec_dos_api_cs IS 'Accessor role for the DoS Capacity Status API.';
+ALTER ROLE uec_dos_api_cs_role WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS PASSWORD 'uec_dos_api_cs_role';
+COMMENT ON ROLE uec_dos_api_cs_role IS 'Accessor role to the DoS DB for the DoS Capacity Status API.';
 
 -- User Configurations
 --
+ALTER ROLE uec_dos_api_cs_role SET search_path TO 'pathwaysdos';
 
-ALTER ROLE CREATE ROLE uec_dos_api_cs_role; SET search_path TO 'pathwaysdos';
+-- Grant usage of schema
+GRANT USAGE ON SCHEMA pathwaysdos TO uec_dos_api_cs_role;
 
--- Grant table permissions
-
+-- Grant specific table permissions
 GRANT SELECT, UPDATE ON pathwaysdos.servicecapacities TO uec_dos_api_cs_role;
 
 GRANT SELECT ON pathwaysdos.users TO uec_dos_api_cs_role;

--- a/deployment/stacks/service/overlays/dev/template/uec-dos-api-cs-proxy-ingress-customisation.yaml
+++ b/deployment/stacks/service/overlays/dev/template/uec-dos-api-cs-proxy-ingress-customisation.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     alb.ingress.kubernetes.io/waf-acl-id: dfae6ec3-aa05-428f-a022-5fd85f646009
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-west-2:730319765130:certificate/c0718115-4e22-4f48-a4aa-8c16ea86c5e6
-    alb.ingress.kubernetes.io/inbound-cidrs: 194.101.83.23/24, 51.140.225.142/24, 81.155.242.0/24, 82.28.50.0/24, 86.136.132.95/24
+    alb.ingress.kubernetes.io/inbound-cidrs: 194.101.83.23/24, 51.140.225.142/24, 81.155.242.0/24, 82.28.50.0/24, 86.132.34.95/24


### PR DESCRIPTION
This PR is for the creation of a specific role created in the DoS DB that the Capacity Status API will use to connect to the DoS Database.  The idea here is to restrict the role to the bare minimum access that the Capacity Status API required in order to fulfil its desired functionality.

Also included in this PR is a fix to the Proxy so that the request received date is forwarded to the API in the request X header in ISO format including milliseconds. This is used so that we can work out the execution time of the request, starting from when we received the request in the proxy.

Finally, a few tweaks to our local deployment configuration.