### PR TITLE
Cast service uid to int for custom sql, to prevent sql injection

### DIFF
--- a/application/api/dos_interface/queries.py
+++ b/application/api/dos_interface/queries.py
@@ -73,7 +73,7 @@ def get_dos_service_for_uid(service_uid, throwDoesNotExist=True):
 def get_service_info(service_uid):
     with connections["dos"].cursor() as cursor:
 
-        cursor.execute(get_service_info_sql, [str(service_uid)])
+        cursor.execute(get_service_info_sql, [str(int(service_uid))])
         result_set = _fetch_all_as_list_of_dicts(cursor)
 
     if not result_set:


### PR DESCRIPTION
This small change will add some additional protection by only allowing numeric characters to be past to the custom sql