### PR TITLE
Add initial throttling configuration to the nginx proxy

### DIFF
--- a/build/docker/proxy/assets/etc/nginx/nginx.conf.template
+++ b/build/docker/proxy/assets/etc/nginx/nginx.conf.template
@@ -30,6 +30,8 @@ http {
     ~\.([0-9]+)$ $1;
   }
 
+  limit_req_zone $binary_remote_addr zone=api-limit:10m rate=3r/s;
+
   server {
     listen 443 ssl;
     server_name localhost;
@@ -39,11 +41,17 @@ http {
 
     add_header X-Request-ID $request_id;
 
+    location / {
+      deny all;
+    }
+
     location /static/ {
+      limit_req zone=api-limit burst=8 nodelay;
       autoindex on;
       root /application;
     }
     location ~ /static/admin {
+      limit_req zone=api-limit burst=8 nodelay;
       autoindex on;
       root /application;
     }
@@ -66,6 +74,8 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Host $server_name;
+
+      limit_req zone=api-limit burst=8 nodelay;
     }
     location /api {
       proxy_pass https://API_HOST_TO_REPLACE;
@@ -77,10 +87,14 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Host $server_name;
       proxy_set_header X-Request-Received $time_iso8601_p1.$millisec+$time_iso8601_p2;
+
+      limit_req zone=api-limit burst=8 nodelay;
     }
     location /health {
       return 200 'healthcheck success from proxy server';
       add_header Content-Type text/plain;
+
+      limit_req zone=api-limit burst=8 nodelay;
     }
   }
   include servers/*;


### PR DESCRIPTION
Added request limits on the nginx configuration. Current request limit is 3 per second inline with the DoS configuration also. We have added a burst of 8, which works like a queue system, these are open to change when exact thresholds can be worked out and users have tested the application. 